### PR TITLE
Vagrant + bootstrap.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Vagrant
+.vagrant/
+
+#nohup.out
+nohup.out

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,82 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "fedora/32-cloud-base"
+  
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  
+  config.vm.provider "virtualbox" do |vb|
+	vb.memory = "1024"
+	end
+	
+	config.vm.network(
+		"forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+		)
+		
+	config.vm.provision "shell", path: "bootstrap.sh", privileged: false
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+# The -e option would make our script exit with an error if any command
+# fails while the -x option makes verbosely it output what it does
+
+# Install Pipenv, the -n option makes sudo fail instead of asking for a
+# password if we don’t have sufficient privileges to run it
+sudo -n dnf install -y pipenv


### PR DESCRIPTION
- Adding bootstrap.sh file
- Adding a Vagrantfile for spinning up a development VM
(and enable files sharing , increasing the amount of memory in our
VM,providing HTTP access into our VM , make vagrant run bootstrap.sh for
us )
- Making changes to the `.gitignore` file to ignore so data that Vagrant
creates and ignore nohup.out file