### PR TITLE
Fixed settings.py and urls.py to work for 'home'

### DIFF
--- a/shlifim/settings.py
+++ b/shlifim/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'landingpage.apps.LandingpageConfig',
+    'home.apps.HomeConfig',
 ]
 
 MIDDLEWARE = [

--- a/shlifim/urls.py
+++ b/shlifim/urls.py
@@ -15,9 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from landingpage import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', views.landingpage, name='landingpage')
 ]


### PR DESCRIPTION
A commit following the last 'Init home app' PR where 'landingpage'
was changed to 'home' but had the files above relate to the previous
name.

modified:   shlifim/settings.py, shlifim/urls.py