### PR TITLE
Creating "ask new question" button in "explore page"

### DIFF
--- a/home/static/home/CSS/base_style.css
+++ b/home/static/home/CSS/base_style.css
@@ -18,3 +18,7 @@ body {
 	color: #000000;
 	padding-top: 20px;
 }
+
+.shlifim-btn{
+  background-color: #A9D4D9;
+}

--- a/home/static/home/CSS/explore-page.css
+++ b/home/static/home/CSS/explore-page.css
@@ -10,10 +10,6 @@
   background-color: #f3ebe6;
 }
 
-.shlifim-btn{
-  background-color: #A9D4D9;
-}
-
 .landing-bg{
 	background-color: #f2dccb;
 }

--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -2,19 +2,24 @@
 {% load static %}
 {% block content %}
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script type="text/javascript" src="{% static 'home/js/explore_page_js.js' %}"></script>
 <link rel="stylesheet" type="text/css" href="{% static 'home/CSS/explore-page.css' %}">
 <body class="main-bg">
 
 <form method="GET" class="container">
 <div class="m-5" >
 
+    <div class="row mb-4">
+        <div class="col-2">
+            <a href="{% url 'new_question' %}" class="btn shlifim-btn" role="button">Ask new question</a>
+        </div>
+
+    </div>
+
 	{% for question in questions %}
 	<div class=" question-display p-2 row m-0 border">
 	    <img class="subject-img" src="{% get_static_prefix %}home\subjects-images\{{question.subject|lower}}.png">
             <div class="col-3">
-                <a style="color:#6FB5EE" href="{% url 'question-detail' question.id %}">{{question.title }}</a>
+                <a style="color:#6FB5EE" href="{% url 'question-detail' question.id %}"><b>{{question.title }}</b></a>
             </div>
             <div class="col">
                 <span>{{ question.subject }} ,{{ question.sub_subject }}</span>

--- a/home/tests/test_explore_page.py
+++ b/home/tests/test_explore_page.py
@@ -34,3 +34,8 @@ class TestExplorePage:
 
             questions = Question.objects.all()
             assert set(explore_page_response.context['questions']) == set(questions)
+
+        @pytest.mark.django_db
+        def test_new_question_btn_in_explore_page(self, explore_page_response):
+            char_content = explore_page_response.content.decode(explore_page_response.charset)
+            assert '<a href="%s"' % reverse("new_question") in char_content


### PR DESCRIPTION
- Creating "ask new question" button in explore page . Clicking on it leads to "new question" page
- Testing "ask new qiestion" btn :
  - Asserting that the response content contains the url of "new question"   page

fix #51 