### PR TITLE
Adding filtering option in "explore page"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 flake8 = "*"
 pytest = "*"
 pytest-django = "*"
+django-filter = "*"
 
 [packages]
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b9ecfdc7980431fdb76e9c6aeaefd077a378f0a12632673b8233ff4f5424a853"
+            "sha256": "3721ad4876e87e5532bd27bf15afa916e6c8eaa4562d01ad4777fdc6df76795e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,11 +32,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:0a1d195ad65c52bf275b8277b3d49680bd1137a5f55039a806f25f6b9752ce3d",
-                "sha256:18dd3145ddbd04bf189ff79b9954d08fda5171ea7b57bf705789fea766a07d50"
+                "sha256:13ac78dbfd189532cad8f383a27e58e18b3d33f80009ceb476d7fcbfc5dcebd8",
+                "sha256:7e0a1393d18c16b503663752a8b6790880c5084412618990ce8a81cc908b4962"
             ],
             "index": "pypi",
-            "version": "==3.2.2"
+            "version": "==3.2.3"
         },
         "django-ckeditor": {
             "hashes": [
@@ -119,12 +119,35 @@
         }
     },
     "develop": {
+        "asgiref": {
+            "hashes": [
+                "sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee",
+                "sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"
+            ],
+            "version": "==3.3.4"
+        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
             "version": "==21.2.0"
+        },
+        "django": {
+            "hashes": [
+                "sha256:13ac78dbfd189532cad8f383a27e58e18b3d33f80009ceb476d7fcbfc5dcebd8",
+                "sha256:7e0a1393d18c16b503663752a8b6790880c5084412618990ce8a81cc908b4962"
+            ],
+            "index": "pypi",
+            "version": "==3.2.3"
+        },
+        "django-filter": {
+            "hashes": [
+                "sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06",
+                "sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
         },
         "flake8": {
             "hashes": [
@@ -205,6 +228,20 @@
             ],
             "index": "pypi",
             "version": "==4.2.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
+            ],
+            "version": "==2021.1"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
+                "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
+            ],
+            "version": "==0.4.1"
         },
         "toml": {
             "hashes": [

--- a/home/filters.py
+++ b/home/filters.py
@@ -1,0 +1,10 @@
+import django_filters
+from .models import Question
+
+
+class QuestionFilter(django_filters.FilterSet):
+    book_page_filter = django_filters.NumberFilter(field_name='book_page', max_value=9999, min_value=1)
+
+    class Meta:
+        model = Question
+        fields = ['subject', 'sub_subject', 'grade', 'book', 'book_page_filter']

--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -10,6 +10,19 @@
 <form method="GET" class="container">
 <div class="m-5" >
 
+
+    <div class="row mb-4">
+    </div>
+
+    <button class=" mb-3 btn btn-secondary" type="button" data-toggle="collapse" data-target="#search-question" aria-expanded="false" aria-controls="collapseExample">
+        Filter
+      </button>
+
+    <div class="row m-4 p-3 w-50 collapsed-bg collapse rounded" id="search-question">
+        {{ filter.form.as_p }}
+        <input class="col-2 btn shlifim-btn ml-2" type="submit" value="Search" />
+    </div>
+
 	{% for question in questions %}
 	<div class=" question-display p-2 row m-0 border">
 	    <img class="subject-img" src="{% get_static_prefix %}home\subjects-images\{{question.subject|lower}}.png">

--- a/home/tests/test_explore_page.py
+++ b/home/tests/test_explore_page.py
@@ -1,6 +1,8 @@
 import pytest
-from home.models import Question
 from django.urls import reverse
+from home.models import Subject, Sub_Subject, Question, Grade, Book
+from django.test import RequestFactory
+from home.views import QuestionsListView
 
 
 class TestExplorePage:
@@ -34,3 +36,74 @@ class TestExplorePage:
 
             questions = Question.objects.all()
             assert set(explore_page_response.context['questions']) == set(questions)
+
+    class TestExplorePageFilter:
+
+        @pytest.fixture
+        def factory(self):
+            return RequestFactory()
+
+        @pytest.mark.django_db
+        @pytest.mark.parametrize("objId", [1, 2, 3])
+        def test_explore_page_filter_by_subject(self, factory, objId):
+            subject = Subject.objects.get(pk=objId)
+            requested_result = Question.objects.all().filter(subject=subject)
+
+            url = reverse('explore-page')
+            request = factory.get(url, {'subject': objId})
+            view = QuestionsListView()
+            view.setup(request)
+            view.object_list = view.get_queryset()
+            assert list(view.get_queryset()) == list(requested_result)
+
+        @pytest.mark.django_db
+        @pytest.mark.parametrize("objId", [1, 2, 3])
+        def test_explore_page_filter_by_sub_subject(self, factory, objId):
+            sub_subject = Sub_Subject.objects.get(pk=objId)
+            requested_result = Question.objects.all().filter(sub_subject=sub_subject)
+
+            url = reverse('explore-page')
+            request = factory.get(url, {'sub_subject': objId})
+            view = QuestionsListView()
+            view.setup(request)
+            view.object_list = view.get_queryset()
+            assert list(view.get_queryset()) == list(requested_result)
+
+        @pytest.mark.parametrize("objId", [1, 2, 3])
+        @pytest.mark.django_db
+        def test_explore_page_filter_by_book(self, factory, objId):
+            book = Book.objects.get(pk=objId)
+            requested_result = Question.objects.all().filter(book=book)
+
+            url = reverse('explore-page')
+            request = factory.get(url, {'book': objId})
+            view = QuestionsListView()
+            view.setup(request)
+            view.object_list = view.get_queryset()
+            assert list(view.get_queryset()) == list(requested_result)
+
+        @pytest.mark.django_db
+        def test_explore_page_filter_by_grade(self, factory):
+            grade = Grade.GRADE7
+            requested_result = Question.objects.all().filter(grade=grade)
+
+            url = reverse('explore-page')
+            request = factory.get(url, {'grade': 7})
+            view = QuestionsListView()
+            view.setup(request)
+            view.object_list = view.get_queryset()
+            assert list(view.get_queryset()) == list(requested_result)
+
+        @pytest.mark.django_db
+        def test_explore_page_filter_zero_results(self, factory):
+            subject = Subject.objects.get(pk=1)
+            grade = Grade.GRADE11
+            requested_result = Question.objects.all().filter(subject=subject).filter(grade=grade)
+
+            url = reverse('explore-page')
+            request = factory.get(url, {'subject': 1, 'grade': 11})
+
+            view = QuestionsListView()
+            view.setup(request)
+            view.object_list = view.get_queryset()
+            assert len(list(view.get_queryset())) == len(list(requested_result)) == 0

--- a/home/views.py
+++ b/home/views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import render
 from .models import Question, Tag
-from django.views.generic.list import ListView
 from .forms import QuestionForm
+from django_filters.views import FilterView
+from django.db.models import Count
+from .filters import QuestionFilter
 
 
 def about(request):
@@ -45,8 +47,21 @@ def new_question(request):
     return render(request, 'home/questions/new_question.html', {'form': form, 'title': 'New Question'})
 
 
-class QuestionsListView(ListView):
+class QuestionsListView(FilterView):
     model = Question
     template_name = 'home/explore.html'
     context_object_name = 'questions'
     ordering = ['-publish_date']
+    filterset_class = QuestionFilter
+
+    def get_queryset(self):
+        items_set = Question.objects.all()
+        ordering = self.request.GET.get('order_by', '-publish_date')
+        if ordering == "answersNum":
+            items_set = items_set.annotate(answers_num=Count('answer')).order_by('-answers_num')
+        else:
+            items_set = items_set.order_by(ordering)
+
+        items_set = QuestionFilter(self.request.GET, queryset=items_set)
+
+        return items_set.qs


### PR DESCRIPTION
- Enable filtering questions in "explore page" by :
  * Subject
  * Sub subject
  * Grade
  * Book
  * Book page

- Add min and max value to the book_page filed so the user will not be able to filter book page by negative value or value bigger than 9999

- Add test to filtering
- Installing django-filter 

fix #50
