### PR TITLE
Adding login page

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -58,7 +58,7 @@
 			  </ul>
 			  {% else %}
 			  <p class="nav-item nav-link m-2"><b>Hello visitor</b></p>
-				<a class="nav-item nav-link m-2" href="#"><b>Login</b></a>
+				<a class="nav-item nav-link m-2" href="{% url 'login' %}"><b>Login</b></a>
 				<a class="nav-item nav-link m-2" href="#"><b>Register<b></a>
 			  {% endif %}
 			</div>

--- a/home/templates/home/login.html
+++ b/home/templates/home/login.html
@@ -1,0 +1,12 @@
+{% extends "home/base.html" %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+  </form>
+{% endblock %}

--- a/home/tests.py
+++ b/home/tests.py
@@ -426,6 +426,42 @@ class TestProfileMiddleware():
 
 
 @pytest.mark.django_db
-def test_login(client):
-    response = client.get('/login')
-    assert response.status_code == 301
+class TestLogin:
+    @pytest.fixture
+    def valid_user_details(self):
+        return {"username": "Lior", "password": "LiorLior"}
+
+    @pytest.fixture
+    def invalid_user_details(self):
+        return {"username": "Lior12", "password": "LiorLior"}
+
+    def test_get_login_page(self, client):
+        response = client.get('/login/')
+        assert response.status_code == 200
+
+    def test_success_login_post_redirect(self, client, valid_user_details):
+        response = client.post('/login/', valid_user_details)
+        assert response.status_code == 302  # redirect
+        assert response.url == '/'
+
+    def test_login(self, client, valid_user_details):
+        client.logout()
+        response = client.get('/')
+        assert not response.wsgi_request.user.is_authenticated  # logged out
+        client.post('/login/', valid_user_details)
+        response = client.get('/')
+        assert response.wsgi_request.user.is_authenticated  # successfully logged in
+
+    def test_unsuccessful_login_post_not_redirect(self, client, invalid_user_details):
+        response = client.post('/login/', invalid_user_details)
+        assert response.status_code == 200  # not redirected
+
+    def test_unsuccessful_login_post_message(self, client, invalid_user_details):
+        response = client.post('/login/', invalid_user_details)
+        assert "Please enter a correct username and password" in str(response.content)
+
+    def test_authenticated_user_view(self, client, valid_user_details):
+        client.login(username=valid_user_details['username'], password=valid_user_details['password'])
+        response = client.get('/')
+        assert "Login" not in str(response.content)
+        assert "Logout" in str(response.content)

--- a/home/tests.py
+++ b/home/tests.py
@@ -423,3 +423,9 @@ class TestProfileMiddleware():
         request_mock = Mock(user=self.LoggedOutUserMock())
         pm.process_view(request_mock, None, None, None)
         assert request_mock.profile is None
+
+
+@pytest.mark.django_db
+def test_login(client):
+    response = client.get('/login')
+    assert response.status_code == 301

--- a/home/urls.py
+++ b/home/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from . import views
 from .views import QuestionsListView
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('about/', views.about, name='about'),
@@ -8,5 +9,6 @@ urlpatterns = [
     path('explore/question_<int:pk>/', views.displayQuestion, name='question-detail'),
     path('tags/', views.tags, name='tags'),
     path('explore/', QuestionsListView.as_view(), name='explore-page'),
-    path('explore/new_question', views.new_question, name='new_question')
+    path('explore/new_question', views.new_question, name='new_question'),
+    path('login/', auth_views.LoginView.as_view(template_name='home/login.html'), name='login')
 ]

--- a/shlifim/settings.py
+++ b/shlifim/settings.py
@@ -115,6 +115,7 @@ USE_L10N = True
 
 USE_TZ = True
 
+LOGIN_REDIRECT_URL = 'about'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/

--- a/shlifim/settings.py
+++ b/shlifim/settings.py
@@ -115,7 +115,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-LOGIN_REDIRECT_URL = 'about'
+LOGIN_REDIRECT_URL = '/'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/


### PR DESCRIPTION
Add Django built in login page. 
Because it's implemented by Django I didn't add tests for that (like login to admin page) except for test approaching /login url.
fix #94 