### PR TITLE
Fix invalid urls routes redirect to 404 page

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.core.validators import MinValueValidator, MaxValueValidator
 from ckeditor.fields import RichTextField
 from django.contrib.auth.models import User
+from django.http import Http404
 
 
 class Gender(models.TextChoices):
@@ -125,6 +126,8 @@ class Question(models.Model):
             answers = answers.order_by('-publish_date')
         elif filterType == 'votes':
             answers = answers.order_by('-likes_count')
+        else:
+            raise Http404()
         return answers
 
     def get_question_title(self):

--- a/home/tests/test_display_question_feature.py
+++ b/home/tests/test_display_question_feature.py
@@ -114,3 +114,15 @@ class TestDisplayQuestionFeature:
             response = client.get(url)
             answer = response.context['answers'].first()
             assert str(answer.content) == expected
+
+        @pytest.mark.django_db
+        def test_invalid_question_url(self, client):
+            url = reverse('question-detail', args=[Question.objects.count()+1])
+            response = client.get(url)
+            assert response.status_code == 404
+
+        @pytest.mark.django_db
+        def test_invalid_answersort_url(self, client):
+            url = '/explore/question_1/?sortanswersby=BAD'
+            response = client.get(url)
+            assert response.status_code == 404

--- a/home/views.py
+++ b/home/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from .models import Question, Tag
 from django.views.generic.list import ListView
 from .forms import QuestionForm
@@ -13,7 +13,7 @@ def landingpage(request):
 
 
 def displayQuestion(request, **kwargs):
-    question = Question.objects.all().get(id=kwargs['pk'])
+    question = get_object_or_404(Question, id=kwargs['pk'])
     sortAnsBy = request.GET["sortanswersby"] if 'sortanswersby' in request.GET else ''
     context = {
         "question": question,


### PR DESCRIPTION
Made it so when a user enters invalid URL like explore/question_999
he will be redirected to 404 instead of server failure

Also fixed the case of the URL /explore/question_1/?sortanswersby=BAD
when sortanswersby is not votes or date, also will go to 404

Added 2 tests, 1 for each case.

fix #100 