### PR TITLE
Fixed question-tag class name & tags page tests

### DIFF
--- a/home/tests.py
+++ b/home/tests.py
@@ -9,7 +9,7 @@ import pytest
 import pytz
 
 
-class TestManyToManyFeature:
+class TestQuestionTagModelFunctions:
     @pytest.mark.django_db
     def test_add_tags_to_question(self, question_test_data):
         test_tags = ['test_tag_1', 'test_tag_2', 'test_tag_3']
@@ -205,9 +205,8 @@ class TestTagsPage:
         assert tags_response.status_code == 200
 
     @pytest.mark.django_db
-    def test_tags_page_context(self, tags_response):
-        expected = '<QuerySet [<Tag: 5th_Grade>, <Tag: Bagrut_Exam>, <Tag: Hebrew>, <Tag: Pitagoras>]>'
-        assert str(tags_response.context['tags']) == expected
+    def test_tags_page_return_type(self, tags_response):
+        assert isinstance(tags_response.context['tags'], QuerySet)
 
     @pytest.mark.django_db
     def test_tags_page_template(self, tags_response):
@@ -218,6 +217,18 @@ class TestTagsPage:
         url = reverse('tags')
         response = client.get(url)
         return response
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(('search, included'), [
+        ('a', '<Tag: Bagrut_Exam>'),
+        ('5', '<Tag: 5th_Grade>'),
+        ('abc', '[]'),
+        ('Pit', '<Tag: Pitagoras>'),
+        ])
+    def test_tags_page_with_search(self, client, search, included):
+        response = client.get('/tags/?q=' + search)
+        assert response.status_code == 200
+        assert included in str(response.context['tags'])
 
 
 class TestExplorePage:


### PR DESCRIPTION
- Fixed the class name of the question-tag model test from
TestManyToManyFeature to TestQuestionTagModelFunctions.
- Changed the function test_tags_page_context to
test_tags_page_return_type, witch uses isinstance to test the returned
type from tags page.
- Added a test that tests the content returned after a search was made
in the tags page.

modified:   home/tests.py