### PR TITLE
Connecting tags page to explore page

### DIFF
--- a/home/static/home/CSS/explore-page.css
+++ b/home/static/home/CSS/explore-page.css
@@ -1,3 +1,9 @@
+.tags-msg
+{
+    background-color: #f2dccb;
+    text-align: center;
+    font-size: 22px;
+}
 
 .subject-img{
 	float:left;
@@ -14,7 +20,6 @@
 	background-color: #f2dccb;
 }
 
-.collapsed-bg
-{
-    background-color: #f3ebe6;
-}
+
+
+

--- a/home/static/home/CSS/tags_style.css
+++ b/home/static/home/CSS/tags_style.css
@@ -26,3 +26,13 @@ form.d-flex button {
     width: 180px;
     text-align: center;
 }
+
+.tag-text
+{
+    text-align: center;
+}
+a {
+    color: #0D0D0D;
+    text-decoration: none;
+
+}

--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -6,20 +6,28 @@
 <body class="main-bg">
 
 <form method="GET" class="container">
-<div class="m-5" >
+<div class="m-3" >
 
-    <div class="row mb-4">
+    <div class="row my-4">
         <div class="col-2">
             <a href="{% url 'new_question' %}" class="btn shlifim-btn" role="button">Ask new question</a>
         </div>
 
     </div>
 
+    {% if tag != None %}
+    <div class="tags-msg p-3">
+        <p><b>Showing all questions that include the tag: #{{ tag }}</b></p>
+        <a href="{% url 'explore-page' %}"><small>Show me all questions</small></a>
+    </div>
+
+    {% endif %}
+
 	{% for question in questions %}
 	<div class=" question-display p-2 row m-0 border">
 	    <img class="subject-img" src="{% get_static_prefix %}home\subjects-images\{{question.subject|lower}}.png">
             <div class="col-3">
-                <a style="color:#6FB5EE" href="{% url 'question-detail' question.id %}"><b>{{question.title }}</b></a>
+                <a style="color:#6FB5EE" href="{% url 'question-detail' question.id %}"><b>{{ question.title }}</b></a>
             </div>
             <div class="col">
                 <span>{{ question.subject }} ,{{ question.sub_subject }}</span>

--- a/home/templates/home/tags.html
+++ b/home/templates/home/tags.html
@@ -18,11 +18,14 @@
                 <br><br>
                 <div class="wrapper">
                     {% for tag in tags %}
-                    <div class="card border-secondary mb-3">
-                        <div class="card-body">
-                            <p class="card-text">{{tag.tag_name}}</p>
+
+                      <div class="card border-secondary mb-3">
+                            <div class="card-body">
+                                <p class="card-text tag-text">
+                                    <a href="{% url 'explore-page' %}?tag={{ tag }}">#{{ tag.tag_name }}</a>
+                                </p>
+                            </div>
                         </div>
-                    </div>
                     {% endfor %}
                 </div>
             </div>

--- a/home/tests/test_explore_page.py
+++ b/home/tests/test_explore_page.py
@@ -4,6 +4,14 @@ from django.urls import reverse
 
 
 class TestExplorePage:
+
+    @pytest.mark.django_db
+    @pytest.fixture
+    def explore_page_response(self, client):
+        url = reverse('explore-page')
+        response = client.get(url)
+        return response
+
     class TestModelFunctions:
 
         @pytest.mark.parametrize("question_id, expected_result", [
@@ -21,13 +29,6 @@ class TestExplorePage:
     class TestExplorePageView:
 
         @pytest.mark.django_db
-        @pytest.fixture
-        def explore_page_response(self, client):
-            url = reverse('explore-page')
-            response = client.get(url)
-            return response
-
-        @pytest.mark.django_db
         def test_explore_page_response(self, explore_page_response):
             assert explore_page_response.status_code == 200
             assert explore_page_response.templates[0].name == "home/explore.html"
@@ -39,3 +40,47 @@ class TestExplorePage:
         def test_new_question_btn_in_explore_page(self, explore_page_response):
             char_content = explore_page_response.content.decode(explore_page_response.charset)
             assert '<a href="%s"' % reverse("new_question") in char_content
+
+    class TestTagsFilter:
+
+        @pytest.mark.parametrize(('tag_name', 'wanted_questions_ids_lst'), [
+            ("Bagrut_Exam", [8, 2, 14]),
+            ("5th_Grade", [4, 3, 1]),
+            ("Pitagoras", [8, 3, 1]),
+        ])
+        @pytest.mark.django_db
+        def test_questions_filter_by_tag(self, client, tag_name, wanted_questions_ids_lst):
+            url = f'/explore/?tag={tag_name}'
+            response = client.get(url)
+
+            requested_questions_ids = response.context['questions'].values_list('id', flat=True)
+            assert wanted_questions_ids_lst == list(requested_questions_ids)
+
+        @pytest.mark.parametrize('tag_name', [
+            "Bagrut_Exam",
+            "5th_Grade",
+            "Pitagoras",
+        ])
+        @pytest.mark.django_db
+        def test_context_with_tags(self, client, tag_name):
+            url = f'/explore/?tag={tag_name}'
+            response = client.get(url)
+
+            requested_tag = response.context['tag']
+            assert requested_tag == tag_name
+
+        @pytest.mark.django_db
+        def test_context_no_tag_parameter(self, explore_page_response):
+            requested_tag = explore_page_response.context['tag']
+            assert requested_tag is None
+
+        @pytest.mark.parametrize('invalid_tag_name', [
+            "AAA",
+            "ERORRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+
+        ])
+        @pytest.mark.django_db
+        def test_invalid_tag(self, client, invalid_tag_name):
+            url = f'/explore/?tag={invalid_tag_name}'
+            response = client.get(url)
+            assert response.status_code == 404

--- a/home/tests/test_tags_page.py
+++ b/home/tests/test_tags_page.py
@@ -34,3 +34,13 @@ class TestTagsPage:
         response = client.get('/tags/?q=' + search)
         assert response.status_code == 200
         assert included in str(response.context['tags'])
+
+    @pytest.mark.parametrize('tag_name', [
+        "Bagrut_Exam",
+        "5th_Grade",
+    ])
+    @pytest.mark.django_db
+    def test_tags_link(self, tags_response, tag_name):
+        char_content = str(tags_response.content)
+        requested_link = "/explore/?tag="+tag_name
+        assert requested_link in char_content

--- a/home/views.py
+++ b/home/views.py
@@ -49,7 +49,24 @@ def new_question(request):
 
 
 class QuestionsListView(ListView):
+
     model = Question
     template_name = 'home/explore.html'
-    context_object_name = 'questions'
     ordering = ['-publish_date']
+
+    def get_context_data(self, **kwargs):
+        requested_tag_name = self.request.GET.get('tag', None)
+
+        if requested_tag_name:
+            requested_tag_obj = get_object_or_404(Tag, tag_name=requested_tag_name)
+            items_set = requested_tag_obj.question_set.all()
+        else:
+            items_set = Question.objects.all()
+
+        context = {
+            'tag': requested_tag_name,
+            'questions': items_set,
+        }
+
+        context.update(kwargs)
+        return super().get_context_data(**context)


### PR DESCRIPTION
 **Connecting tags page to explore page:**

Clicking on tag name in tags page leads to explore page filter by the
selected tag

- Updating views.py file :
  * Adding get_queryset function in order to show only questions with the requested tag name
- updating tags.html file :
  * Adding link for each tag in tags page that leads to explore page
 filtered by this tag
- Updating explore.html file:
  * Adding message indicates the questions are filtered by specific tag

**Adding tests**
- Updating test_explore_page.py file:
  * Testing content received after GET requests with a tag parameter
    contains only qeuestions with this specific tag .
  * Testing context received after GET requests with a tag parameter
    contain this tag.
  * Testing context received after GET requests without a tag parameter
    contain None
  * Testing GET requests with a tag parameter that does not exist in
     the site raises 404 error

- Updating test_tags_page.py file :
  * Testing each tag contain url to the expxlore page with the requested
    tag

**updating css files**

fix #124
Done with @rebeccaTubman 