### PR TITLE
fix None subsubject in explore

### DIFF
--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -31,7 +31,10 @@
             </div>
             <div class="col-3">
                 <div class="row">
-                    <span>{{ question.subject }} ,{{ question.sub_subject }}</span>
+                    <span>{{ question.subject }}
+					{% if question.sub_subject != None %}
+					, {{ question.sub_subject }}
+					{% endif %} </span>
                 </div>
                 <div class="row mt-2">
                         <div >


### PR DESCRIPTION
Visual change only on explore page - to remove "None" when there is no sub-subject.
You can see the change in the issue fix #136 