### PR TITLE
Changed urls names

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -26,7 +26,7 @@
 	<body>
 	<nav class="navbar navbar-expand-lg navbar-light">
 	  <div class="container-fluid">
-		<a class="nav-link active" href="{% url 'landingpage' %}">
+		<a class="nav-link active" href="{% url 'landing-page' %}">
 			<img  class="m-2" src="{% static 'home/logo.png' %}"
 			alt="shlifim logo" width="120" height="45"></a>
 		<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -45,7 +45,7 @@
 				</li>
 				<li class="nav-item">
 					{% if user.is_authenticated %}
-						<a class="nav-link" href="{% url 'new_question' %}">Ask</a>
+						<a class="nav-link" href="{% url 'new-question' %}">Ask</a>
 					{% endif %}
 				</li>
 			</ul>

--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -10,7 +10,7 @@
 
     <div class="row my-4">
         <div class="col-2">
-            <a href="{% url 'new_question' %}" class="btn shlifim-btn" role="button">Ask new question</a>
+            <a href="{% url 'new-question' %}" class="btn shlifim-btn" role="button">Ask new question</a>
         </div>
 
     </div>

--- a/home/tests/test_explore_page.py
+++ b/home/tests/test_explore_page.py
@@ -39,7 +39,7 @@ class TestExplorePage:
         @pytest.mark.django_db
         def test_new_question_btn_in_explore_page(self, explore_page_response):
             char_content = explore_page_response.content.decode(explore_page_response.charset)
-            assert '<a href="%s"' % reverse("new_question") in char_content
+            assert '<a href="%s"' % reverse("new-question") in char_content
 
     class TestTagsFilter:
 

--- a/home/urls.py
+++ b/home/urls.py
@@ -5,10 +5,10 @@ from .views import QuestionsListView
 
 urlpatterns = [
     path('about/', views.about, name='about'),
-    path('', views.landingpage, name='landingpage'),
+    path('', views.landingpage, name='landing-page'),
     path('tags/', views.tags, name='tags'),
     path('explore/', QuestionsListView.as_view(), name='explore-page'),
-    path('explore/new_question', views.new_question, name='new_question'),
+    path('explore/new_question', views.new_question, name='new-question'),
     path('login/', auth_views.LoginView.as_view(template_name='home/login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('signup/', views.signup, name='signup'),


### PR DESCRIPTION
Changed the following:
'landingpage' -> 'landing-page'
'new_question' -> 'new-question'

The change is in the urls.py file, but also in the HTML files that call the URLs,
and also in one test that used an old name.

This is so the URLs names will be consistent and in format
fix #142 