### PR TITLE
Added link from tags to explore page

### DIFF
--- a/home/static/home/CSS/base_style.css
+++ b/home/static/home/CSS/base_style.css
@@ -40,3 +40,14 @@ body {
 	padding-left:5px;
 	padding-right:5px;
 }
+
+
+a.nostyle:link {
+    text-decoration: inherit;
+    color: inherit;
+}
+
+a.nostyle:visited {
+    text-decoration: inherit;
+    color: inherit;
+}

--- a/home/templates/home/explore.html
+++ b/home/templates/home/explore.html
@@ -39,7 +39,9 @@
                 <div class="row mt-2">
                         <div >
                             {% for tag in question.tag_set.all %}
-                                <span class="badge badge-pill badge-secondary">#{{tag.tag_name}}</span>
+                                <span class="badge badge-pill badge-secondary">
+								 <a href="{% url 'explore-page' %}?tag={{ tag }}" class="nostyle">
+								#{{tag.tag_name}}</a></span>
                             {% endfor %}
                         </div>
                 </div>

--- a/home/templates/home/question_detail.html
+++ b/home/templates/home/question_detail.html
@@ -26,7 +26,9 @@
 		</div>
 		 <div class="pt-2">
 				{% for tag in question.tag_set.all %}
-					<span class="badge badge-pill badge-secondary">#{{tag.tag_name}}</span>
+				   <span class="badge badge-pill badge-secondary">
+							 <a href="{% url 'explore-page' %}?tag={{ tag }}" class="nostyle">
+							#{{tag.tag_name}}</a></span>
 				{% endfor %}
           </div>
 	</div>


### PR DESCRIPTION
In every place we display tags, (explore page and display question
page) I added an option to click on the tag's badge and it will redirect
to the explore page filtered to show all questions with this tag.

No tests were added because this link's URL has already been
tested during the tags page feature.
fix #148