### PR TITLE
Change client.login to client.force_login

### DIFF
--- a/home/tests/conftest.py
+++ b/home/tests/conftest.py
@@ -3,7 +3,6 @@ import pytz
 from home.models import Profile, Subject, Question, Answer
 from django.contrib.auth.models import User
 from django.utils import timezone
-from django.contrib.auth import authenticate
 from datetime import datetime
 
 
@@ -37,10 +36,8 @@ def profile():
 
 @pytest.fixture
 def authenticated_user(client, request):
-    username = 'Lior'
-    password = 'LiorLior'
-    client.login(username=username, password=password)
-    user = authenticate(request, username=username, password=password)
+    user = User.objects.get(username='Lior')
+    client.force_login(user)
     return user
 
 

--- a/home/tests/test_login.py
+++ b/home/tests/test_login.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth.models import User
 
 
 @pytest.mark.django_db
@@ -33,7 +34,8 @@ class TestLogin:
         assert "Please enter a correct username and password" in str(response.content)
 
     def test_authenticated_user_view(self, client, valid_user_details):
-        client.login(username=valid_user_details['username'], password=valid_user_details['password'])
+        user = User.objects.get(username=valid_user_details['username'])
+        client.force_login(user)
         response = client.get('/')
         assert "Login" not in str(response.content)
         assert "Logout" in str(response.content)


### PR DESCRIPTION
Reduces Testing time from 44.58s to 17.50s.

force_login was recommended by Barak, and it does the same as a login but without the encryption/authentication logic behind the scenes so it faster.

fix #150 