### PR TITLE
Add the use of reverse method in tests

### DIFF
--- a/home/tests/test_about_page.py
+++ b/home/tests/test_about_page.py
@@ -2,8 +2,8 @@ import pytest
 from django.urls import reverse
 
 
+@pytest.mark.django_db
 class TestAboutPage:
-    @pytest.mark.django_db
     @pytest.fixture
     def about_page_response(self, client):
         url = reverse("about")
@@ -13,7 +13,6 @@ class TestAboutPage:
     def test_about_page_url(self, about_page_response):
         assert about_page_response.status_code == 200
 
-    @pytest.mark.django_db
     @pytest.mark.parametrize(
         ("link"),
         [

--- a/home/tests/test_add_answer.py
+++ b/home/tests/test_add_answer.py
@@ -1,27 +1,41 @@
 from home.models import Answer
+from django.urls import reverse
 import pytest
 
 
 @pytest.mark.django_db
 class TestAddAnswer:
     @pytest.fixture
+    def question_details_url(self, question_test_data):
+        return reverse("question-detail", args=[question_test_data.id])
+
+    @pytest.fixture
     def comment_content(self):
         return {"content": "test"}
 
     def test_post_redirect(
-        self, client, question_test_data, authenticated_user, comment_content
+        self, client, question_details_url, authenticated_user, comment_content
     ):
         response = client.post(
-            f"/explore/question_{question_test_data.id}/", data=comment_content
+            question_details_url,
+            data=comment_content,
         )
         assert response.status_code == 302  # check that redirect
         # redirect back to the same display question page
-        assert response.url == f"/explore/question_{question_test_data.id}/"
+        assert response.url == question_details_url
 
     def test_add_answer_post(
-        self, authenticated_user, client, question_test_data, comment_content
+        self,
+        authenticated_user,
+        client,
+        question_details_url,
+        question_test_data,
+        comment_content,
     ):
-        client.post(f"/explore/question_{question_test_data.id}/", data=comment_content)
+        client.post(
+            question_details_url,
+            data=comment_content,
+        )
         answers_feed = question_test_data.get_answers_feed()
         assert (
             answers_feed.first().id
@@ -34,16 +48,18 @@ class TestAddAnswer:
         )  # answer profile is the user that posted.
 
     def test_html_authenticated_user_form_visible(
-        self, authenticated_user, question_test_data, client
+        self, authenticated_user, question_details_url, client
     ):
-        response = client.get(f"/explore/question_{question_test_data.id}/")
+        response = client.get(question_details_url)
         # comment-form is the div id of the comment-form, should be visible (because it is authenticated user)
         assert "comment-form" in str(response.content)
         # not-authenticated is the div for login button for not authenticated user, should be hidden
         assert "not-authenticated" not in str(response.content)
 
-    def test_html_not_authenticated_user_form_visible(self, question_test_data, client):
-        response = client.get(f"/explore/question_{question_test_data.id}/")
+    def test_html_not_authenticated_user_form_visible(
+        self, question_details_url, client
+    ):
+        response = client.get(question_details_url)
         # should be hidden for not authenticated user
         assert "comment-form" not in str(response.content)
         # login button for not authenticated user should be visible
@@ -68,27 +84,28 @@ class TestAddAnswer:
         ).issubset(list(out.values_list("profile", "question", "content")))
 
     def test_post_answer_not_authenticated_user(
-        self, client, question_test_data, comment_content
+        self, client, question_details_url, comment_content
     ):
         response = client.post(
-            f"/explore/question_{question_test_data.id}/", data=comment_content
+            question_details_url,
+            data=comment_content,
         )
         assert response.status_code == 401
 
     def test_valid_tags_not_removed_from_answer(
-        self, client, question_test_data, authenticated_user
+        self, client, question_test_data, question_details_url, authenticated_user
     ):
         data = {"content": "<p>test</p>"}
-        client.post(f"/explore/question_{question_test_data.id}/", data=data)
+        client.post(question_details_url, data=data)
         answer = question_test_data.get_answers_feed().first()
         assert "<p>" in answer.content
 
     def test_invalid_tags_removed_from_question(
-        self, client, question_test_data, authenticated_user
+        self, client, question_test_data, question_details_url, authenticated_user
     ):
         data = {
             "content": '<script language = "javascript" > alert("You are PWNED!") </script>'
         }
-        client.post(f"/explore/question_{question_test_data.id}/", data=data)
+        client.post(question_details_url, data=data)
         answer = question_test_data.get_answers_feed().first()
         assert "<script>" not in answer.content

--- a/home/tests/test_delete_question.py
+++ b/home/tests/test_delete_question.py
@@ -7,45 +7,38 @@ TEST_SECOND_QUESTION_ID = 3
 
 
 @pytest.mark.django_db
-def test_delete_button_visible(logged_client):
-    response = logged_client.get(reverse("question-detail", args=[TEST_QUESTION_ID]))
-    char_content = response.content.decode(response.charset)
-    assert 'value="Delete"' in char_content
+class TestDeleteQuestionFeature:
+    question_detail_url_1 = reverse("question-detail", args=[TEST_QUESTION_ID])
+    question_delete_url_1 = reverse("question-delete", args=[TEST_QUESTION_ID])
+    question_delete_url_2 = reverse("question-delete", args=[TEST_SECOND_QUESTION_ID])
 
+    def test_delete_button_visible(self, logged_client):
+        response = logged_client.get(self.question_detail_url_1)
+        char_content = response.content.decode(response.charset)
+        assert 'value="Delete"' in char_content
 
-@pytest.mark.django_db
-def test_delete_button_invisible(client):
-    response = client.get(reverse("question-detail", args=[TEST_QUESTION_ID]))
-    char_content = response.content.decode(response.charset)
-    assert 'value="Delete"' not in char_content
+    def test_delete_button_invisible(self, client):
+        response = client.get(self.question_detail_url_1)
+        char_content = response.content.decode(response.charset)
+        assert 'value="Delete"' not in char_content
 
+    def test_unsigned_user_delete(self, client):
+        response = client.post(self.question_delete_url_2)
+        assert response.status_code == 401
 
-@pytest.mark.django_db
-def test_unsigned_user_delete(client):
-    response = client.post(reverse("question-delete", args=[TEST_SECOND_QUESTION_ID]))
-    assert response.status_code == 401
+    def test_unauthorized_user_delete(self, logged_client):
+        response = logged_client.post(self.question_delete_url_2)
+        assert response.status_code == 401
 
+    def test_legit_delete_post(self, logged_client):
+        response = logged_client.post(self.question_delete_url_1)
+        assert response.status_code == 302
+        assert response.url == reverse("explore-page")
+        assert not Question.objects.all().filter(id=TEST_QUESTION_ID).exists()
 
-@pytest.mark.django_db
-def test_unauthorized_user_delete(logged_client):
-    response = logged_client.post(
-        reverse("question-delete", args=[TEST_SECOND_QUESTION_ID])
-    )
-    assert response.status_code == 401
-
-
-@pytest.mark.django_db
-def test_legit_delete_post(logged_client):
-    response = logged_client.post(reverse("question-delete", args=[TEST_QUESTION_ID]))
-    assert response.status_code == 302
-    assert response.url == reverse("explore-page")
-    assert not Question.objects.all().filter(id=TEST_QUESTION_ID).exists()
-
-
-@pytest.mark.django_db
-def test_delete_question_success_msg(logged_client):
-    response = logged_client.post(reverse("question-delete", args=[TEST_QUESTION_ID]))
-    response = logged_client.get(response.url)
-    messages = list(response.context["messages"])
-    assert len(messages) == 1
-    assert str(messages[0].message) == "SUCCESS: Your question has been deleted."
+    def test_delete_question_success_msg(self, logged_client):
+        response = logged_client.post(self.question_delete_url_1)
+        response = logged_client.get(response.url)
+        messages = list(response.context["messages"])
+        assert len(messages) == 1
+        assert str(messages[0].message) == "SUCCESS: Your question has been deleted."

--- a/home/tests/test_display_question_feature.py
+++ b/home/tests/test_display_question_feature.py
@@ -10,9 +10,9 @@ INVALID_ANSWER_ID = 999999
 TEST_QUESTION_ID = 14
 
 
+@pytest.mark.django_db
 class TestDisplayQuestionFeature:
     class TestAnswersManipulations:
-        @pytest.mark.django_db
         def test_set_is_edited(self, answers):
             """
             Tests functionality of set_is_edited
@@ -36,7 +36,6 @@ class TestDisplayQuestionFeature:
             assert answers_feed[0].content == expected
 
     class TestQuestionRelatedMethods:
-        @pytest.mark.django_db
         def test_get_question_title(self):
             """
             get_question_title(question_id) returns a string for question
@@ -46,25 +45,21 @@ class TestDisplayQuestionFeature:
             assert question.get_question_title() == "Math-question from math course"
 
     class TestHTMLRelated:
-        @pytest.mark.django_db
         @pytest.fixture
         def response(self, client):
             url = reverse("question-detail", args=[14])
             response = client.get(url)
             return response
 
-        @pytest.mark.django_db
         def test_display_question_page_url(self, response):
             """
             This test checks the returned status for routing to display-question feature
             """
             assert response.status_code == 200
 
-        @pytest.mark.django_db
         def test_template_name(self, response):
             assert response.templates[0].name == "home/question_detail.html"
 
-        @pytest.mark.django_db
         def test_response_context(self, response):
             """
             Testing if the context passed to the view contains the right contents
@@ -97,27 +92,25 @@ class TestDisplayQuestionFeature:
             ("filter_type, expected"),
             [("date", "Answer B"), ("votes", "Popular Answer")],
         )
-        @pytest.mark.django_db
         def test_sorting_answers(self, client, filter_type, expected):
-            url = f"/explore/question_14/?sortanswersby={filter_type}"
-            response = client.get(url)
+            url = reverse("question-detail", args=[14])
+            query_params = f"?sortanswersby={filter_type}"
+            response = client.get(url + query_params)
             answer = response.context["answers_tuples"][0][0]
             assert str(answer.content) == expected
 
-        @pytest.mark.django_db
         def test_invalid_question_url(self, client):
             url = reverse("question-detail", args=[Question.objects.count() + 1])
             response = client.get(url)
             assert response.status_code == 404
 
-        @pytest.mark.django_db
         def test_invalid_answersort_url(self, client):
-            url = "/explore/question_1/?sortanswersby=BAD"
-            response = client.get(url)
+            url = reverse("question-detail", args=[1])
+            query_params = "?sortanswersby=BAD"
+            response = client.get(url + query_params)
             assert response.status_code == 404
 
     class TestThumbsRouting:
-        @pytest.mark.django_db
         def test_logged_user_good_route(self, logged_client):
             response = logged_client.get(
                 f"/explore/question_{TEST_QUESTION_ID}/thumb/up/{DISLIKED_ANSWER_ID}"
@@ -134,12 +127,10 @@ class TestDisplayQuestionFeature:
                 (f"/explore/question_{TEST_QUESTION_ID}/thumb/up/{INVALID_ANSWER_ID}"),
             ],
         )
-        @pytest.mark.django_db
         def test_logged_user_bad_route(self, logged_client, bad_url):
             response = logged_client.get(bad_url)
             assert response.status_code == 404
 
-        @pytest.mark.django_db
         def test_unauthorized_response(self, client):
             response = client.get(f"/explore/question_{TEST_QUESTION_ID}/thumb/up/9")
             assert response.status_code == 401
@@ -154,7 +145,6 @@ class TestDisplayQuestionFeature:
                 (LIKED_ANSWER_ID, "down", False, True),
             ],
         )
-        @pytest.mark.django_db
         def test_thumbs_view(
             self, logged_client, answer_id, thumb_type, like_val, false_val
         ):
@@ -167,7 +157,6 @@ class TestDisplayQuestionFeature:
                 if answer.id == answer_id:
                     assert like == like_val and dislike == false_val
 
-        @pytest.mark.django_db
         def test_like_dislike_fields_update(self, answers, logged_client):
             answer_id1 = answers[0].id
             answer_id2 = answers[1].id

--- a/home/tests/test_login.py
+++ b/home/tests/test_login.py
@@ -1,42 +1,46 @@
 import pytest
 from django.contrib.auth.models import User
+from django.urls import reverse
 
 
 @pytest.mark.django_db
 class TestLogin:
+    landing_page_url = reverse("landing-page")
+    login_url = reverse("login")
+
     @pytest.fixture
     def invalid_user_details(self):
         return {"username": "Lior12", "password": "LiorLior"}
 
     def test_get_login_page(self, client):
-        response = client.get("/login/")
+        response = client.get(self.login_url)
         assert response.status_code == 200
 
     def test_success_login_post_redirect(self, client, valid_user_details):
-        response = client.post("/login/", valid_user_details)
+        response = client.post(self.login_url, valid_user_details)
         assert response.status_code == 302  # redirect
-        assert response.url == "/"
+        assert response.url == self.landing_page_url
 
     def test_login(self, client, valid_user_details):
         client.logout()
-        response = client.get("/")
+        response = client.get(self.landing_page_url)
         assert not response.wsgi_request.user.is_authenticated  # logged out
         client.post("/login/", valid_user_details)
-        response = client.get("/")
+        response = client.get(self.landing_page_url)
         assert response.wsgi_request.user.is_authenticated  # successfully logged in
 
     def test_unsuccessful_login_post_not_redirect(self, client, invalid_user_details):
-        response = client.post("/login/", invalid_user_details)
+        response = client.post(self.login_url, invalid_user_details)
         assert response.status_code == 200  # not redirected
 
     def test_unsuccessful_login_post_message(self, client, invalid_user_details):
-        response = client.post("/login/", invalid_user_details)
+        response = client.post(self.login_url, invalid_user_details)
         assert "Please enter a correct username and password" in str(response.content)
 
     def test_authenticated_user_view(self, client, valid_user_details):
         user = User.objects.get(username=valid_user_details["username"])
         client.force_login(user)
-        response = client.get("/")
+        response = client.get(self.landing_page_url)
         assert "Login" not in str(response.content)
         assert "Logout" in str(response.content)
 

--- a/home/tests/test_logout.py
+++ b/home/tests/test_logout.py
@@ -1,26 +1,30 @@
 import pytest
+from django.urls import reverse
 
 
 @pytest.mark.django_db
 class TestLogout:
+    landing_page_url = reverse("landing-page")
+    logout_url = reverse("logout")
+
     def test_status_code(self, client):
-        response = client.get("/logout/")
+        response = client.get(self.logout_url)
         assert response.status_code == 302  # redirected
 
     def test_redirection_default_url(self, client):
-        response = client.get("/logout/")
-        assert response.url == "/"  # redirected to home page.
+        response = client.get(self.logout_url)
+        assert response.url == self.landing_page_url  # redirected to home page.
 
     def test_logout(self, client, authenticated_user):
-        response = client.get("/")
+        response = client.get(self.landing_page_url)
         assert response.wsgi_request.user.is_authenticated  # successfully logged in
-        response = client.get("/logout/")
+        response = client.get(self.logout_url)
         assert (
             not response.wsgi_request.user.is_authenticated
         )  # successfully logged out
 
     def test_unauthenticated_user_view(self, client):
-        response = client.get("/")
+        response = client.get(self.landing_page_url)
         assert "Login" in str(response.content)
         assert "Logout" not in str(response.content)
 

--- a/home/tests/test_profile_middleware.py
+++ b/home/tests/test_profile_middleware.py
@@ -6,27 +6,27 @@ from home.models import Profile
 
 
 class TestProfileMiddleware:
+    @pytest.mark.django_db
     class LoggedOutUserMock:
         is_authenticated = False
 
-    @pytest.mark.django_db
-    def test_process_request_with_logged_in_user(self):
-        logged_in_user = User.objects.latest("id")
-        pm = ProfileMiddleware("response")
-        assert logged_in_user.is_authenticated is True
+        def test_process_request_with_logged_in_user(self):
+            logged_in_user = User.objects.latest("id")
+            pm = ProfileMiddleware("response")
+            assert logged_in_user.is_authenticated is True
 
-        request_mock = Mock(user=User.objects.latest("id"))
-        pm.process_view(request_mock, None, None, None)
-        assert (
-            request_mock.profile == Profile.objects.filter(user=logged_in_user).first()
-        )
+            request_mock = Mock(user=User.objects.latest("id"))
+            pm.process_view(request_mock, None, None, None)
+            assert (
+                request_mock.profile
+                == Profile.objects.filter(user=logged_in_user).first()
+            )
 
-    @pytest.mark.django_db
-    def test_process_request_with_logged_out_user(self):
-        logged_out_user = self.LoggedOutUserMock()
-        pm = ProfileMiddleware("response")
-        assert logged_out_user.is_authenticated is False
+        def test_process_request_with_logged_out_user(self):
+            logged_out_user = self.LoggedOutUserMock()
+            pm = ProfileMiddleware("response")
+            assert logged_out_user.is_authenticated is False
 
-        request_mock = Mock(user=self.LoggedOutUserMock())
-        pm.process_view(request_mock, None, None, None)
-        assert request_mock.profile is None
+            request_mock = Mock(user=self.LoggedOutUserMock())
+            pm.process_view(request_mock, None, None, None)
+            assert request_mock.profile is None

--- a/home/tests/test_question_tag_model_functions.py
+++ b/home/tests/test_question_tag_model_functions.py
@@ -2,8 +2,8 @@ import pytest
 from home.models import Tag, Question_Tag
 
 
+@pytest.mark.django_db
 class TestQuestionTagModelFunctions:
-    @pytest.mark.django_db
     def test_add_tags_to_question(self, question_test_data):
         test_tags = ["test_tag_1", "test_tag_2", "test_tag_3"]
         question_test_data.add_tags_to_question(test_tags)
@@ -14,17 +14,14 @@ class TestQuestionTagModelFunctions:
             {"id": 23, "tag_name": "test_tag_3"},
         ]
 
-    @pytest.mark.django_db
     def test_field_questions_in_tag(self, question_tag_test_data):
         assert question_tag_test_data.questions.values().count() == 1
 
-    @pytest.mark.django_db
     def test_question_tag_table(self, question_test_data, question_tag_test_data):
         assert Question_Tag.objects.filter(
             question=question_test_data, tag=question_tag_test_data
         ).exists()
 
-    @pytest.mark.django_db
     def test_add_tags_to_question_one_new_input(
         self, question_test_data, question_tag_test_data
     ):

--- a/home/tests/test_tag_model_functions.py
+++ b/home/tests/test_tag_model_functions.py
@@ -2,6 +2,7 @@ import pytest
 from home.models import Tag
 
 
+@pytest.mark.django_db
 class TestTagModelFunctions:
     @pytest.mark.parametrize(
         "valid_tags",
@@ -14,7 +15,6 @@ class TestTagModelFunctions:
             (["beyond_01", "beyond_02", "beyond_03", "beyond_04", "beyond_05"]),
         ],
     )
-    @pytest.mark.django_db
     def test_check_tag_array_valid_data(self, valid_tags):
         assert Tag.check_tag_array(valid_tags) is True
 
@@ -35,28 +35,22 @@ class TestTagModelFunctions:
             ),
         ],
     )
-    @pytest.mark.django_db
     def test_check_tag_array_invalid_data(self, invalid_tags):
         assert Tag.check_tag_array(invalid_tags) is False
 
-    @pytest.mark.django_db
     def test_tags_feed_no_parameters(self):
         assert Tag.tags_feed().count() == 20
 
-    @pytest.mark.django_db
     def test_tags_feed_with_test_tag(self, tag_test_data):
         assert tag_test_data.tags_feed().count() == 21
 
-    @pytest.mark.django_db
     def test_tags_feed_with_filter(self, tag_test_data):
         assert Tag.tags_feed("_t").count() == 1
 
-    @pytest.mark.django_db
     def test_tags_feed_after_delete(self, tag_test_data):
         Tag.objects.filter(tag_name="test_tag_1").delete()
         assert Tag.tags_feed().count() == 20
 
-    @pytest.mark.django_db
     def test_tags_feed_no_result(self):
         assert Tag.tags_feed("testtesttesttest").count() == 0
 

--- a/home/tests/test_tags_page.py
+++ b/home/tests/test_tags_page.py
@@ -4,16 +4,14 @@ from pytest_django.asserts import assertTemplateUsed
 from django.db.models.query import QuerySet
 
 
+@pytest.mark.django_db
 class TestTagsPage:
-    @pytest.mark.django_db
     def test_tags_page_url(self, tags_response):
         assert tags_response.status_code == 200
 
-    @pytest.mark.django_db
     def test_tags_page_return_type(self, tags_response):
         assert isinstance(tags_response.context["tags"], QuerySet)
 
-    @pytest.mark.django_db
     def test_tags_page_template(self, tags_response):
         assertTemplateUsed(tags_response, "home/tags.html")
 
@@ -23,7 +21,6 @@ class TestTagsPage:
         response = client.get(url)
         return response
 
-    @pytest.mark.django_db
     @pytest.mark.parametrize(
         ("search, included"),
         [
@@ -45,7 +42,6 @@ class TestTagsPage:
             "5th_Grade",
         ],
     )
-    @pytest.mark.django_db
     def test_tags_link(self, tags_response, tag_name):
         char_content = str(tags_response.content)
         requested_link = "/explore/?tag=" + tag_name


### PR DESCRIPTION
Switched the code so that tests will use reverse instead of hard-wired URLs, so if we change the URLs in the future, it will automatically change in the tests.

edit: Also moved @pytest.mark.django_db tag above the class header, so it won't repeat every test header

fix #159 