### PR TITLE
Fix the url for the 'login to like' link

### DIFF
--- a/home/templates/home/answers_display.html
+++ b/home/templates/home/answers_display.html
@@ -33,7 +33,7 @@
 			  </a>
 			  {{ answer.dislikes.count }}
 			  {% if not is_user_logged_in %}
-				<small><a href="{% url 'login' %}">Login</a> to like</small>
+				<small><a href="{% url 'login' %}?next={% firstof request.path '/' %}">Login</a> to like</small>
 			 {% endif %}
         </div>
 		</div>


### PR DESCRIPTION
Previously the href was just "login", but now I added the
addition of the "next" param which will redirect the user back
to the same page after logging

*Note that tests for login redirect are already exist, it just that by mistake I didn't use this 
ability in the 'log in to like' link 

fix #172 