### PR TITLE
Prevent email duplication

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -25,3 +25,14 @@ class SignUpForm(UserCreationForm):
             "password1",
             "password2",
         )
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+
+        registered_email_count = User.objects.filter(email=email).count()
+
+        if email and registered_email_count > 0:
+            raise forms.ValidationError(
+                "This email address is already in use. Please supply a different email address."
+            )
+        return email

--- a/users/tests/test_signup.py
+++ b/users/tests/test_signup.py
@@ -57,6 +57,17 @@ class TestSignUp:
                 },
                 "email",
             ],
+            # email already in use
+            [
+                {
+                    "username": "valid_username2",
+                    "email": "Ido@gmail.com",
+                    "gender": "U",
+                    "password1": "IdoIdo123",
+                    "password2": "IdoIdo123",
+                },
+                "email",
+            ],
             # password to short
             [
                 {


### PR DESCRIPTION
This is an upgrade for the validation of the signup form, not allowing a user to register with
an already-used email address.

the changes are in the signup form and signup tests.

fix #180 