### PR TITLE
Fix client.get calls, to use param dictionary

### DIFF
--- a/home/tests/test_display_question_feature.py
+++ b/home/tests/test_display_question_feature.py
@@ -94,8 +94,8 @@ class TestDisplayQuestionFeature:
         )
         def test_sorting_answers(self, client, filter_type, expected):
             url = reverse("question-detail", args=[14])
-            query_params = f"?sortanswersby={filter_type}"
-            response = client.get(url + query_params)
+            param_dict = {"sortanswersby": filter_type}
+            response = client.get(url, param_dict)
             answer = response.context["answers_tuples"][0][0]
             assert str(answer.content) == expected
 
@@ -106,8 +106,8 @@ class TestDisplayQuestionFeature:
 
         def test_invalid_answersort_url(self, client):
             url = reverse("question-detail", args=[1])
-            query_params = "?sortanswersby=BAD"
-            response = client.get(url + query_params)
+            param_dict = {"sortanswersby": "BAD"}
+            response = client.get(url, param_dict)
             assert response.status_code == 404
 
     class TestThumbsRouting:

--- a/home/tests/test_explore_page.py
+++ b/home/tests/test_explore_page.py
@@ -54,8 +54,9 @@ class TestExplorePage:
         def test_questions_filter_by_tag(
             self, client, tag_name, wanted_questions_ids_lst
         ):
-            url = f"/explore/?tag={tag_name}"
-            response = client.get(url)
+            url = reverse("explore-page")
+            param_dict = {"tag": tag_name}
+            response = client.get(url, param_dict)
 
             requested_questions_ids = response.context["questions"].values_list(
                 "id", flat=True
@@ -73,8 +74,8 @@ class TestExplorePage:
         def test_context_with_tags(self, client, tag_name):
 
             url = self.explore_page_url
-            query_params = f"?tag={tag_name}"
-            response = client.get(url + query_params)
+            param_dict = {"tag": tag_name}
+            response = client.get(url, param_dict)
             requested_tag = response.context["tag"]
             assert requested_tag == tag_name
 
@@ -91,8 +92,8 @@ class TestExplorePage:
         )
         def test_invalid_tag(self, client, invalid_tag_name):
             url = self.explore_page_url
-            query_params = f"?tag={invalid_tag_name}"
-            response = client.get(url + query_params)
+            param_dict = {"tag": invalid_tag_name}
+            response = client.get(url, param_dict)
             assert response.status_code == 404
 
         @pytest.mark.parametrize("tag_name", ["#Pitagoras", "#Bagrut_Exam"])

--- a/home/tests/test_insert_question_feature.py
+++ b/home/tests/test_insert_question_feature.py
@@ -381,7 +381,7 @@ class TestInsertQuestionFeature:
                         "content": "How much is it 1+1?",
                         "tags_": "",
                         "subject": 1,
-                        "sub_subject": 10
+                        "sub_subject": 10,
                     }
                 )
                 # User entered all subsubject not matching the subject

--- a/home/tests/test_tags_page.py
+++ b/home/tests/test_tags_page.py
@@ -31,7 +31,8 @@ class TestTagsPage:
         ],
     )
     def test_tags_page_with_search(self, client, search, included):
-        response = client.get("/tags/?q=" + search)
+        param_dict = {"q": search}
+        response = client.get("/tags/", param_dict)
         assert response.status_code == 200
         assert included in str(response.context["tags"])
 


### PR DESCRIPTION
In the official Django doc for the client.get function, it mentioned
that if you want to make a request with query param you can
send key-value pairs (dictionary)

fix #187 